### PR TITLE
Only pull config if changes

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,6 @@
-import boto3
 import os
-import pytz
 from utils.s3_file_handler import S3FileHandler
 from utils.local_file_handler import LocalFileHandler
-from datetime import datetime
 
 IS_LOCAL = True if os.environ.get("IS_LOCAL", "False") == "True" else False
 
@@ -14,7 +11,6 @@ if LocalFileHandler().check_file_exists(file_path="config.json"):
     NOT_FOUND = False
 else:
     print("Local config not found")
-    local_datetime = datetime(1970, 1, 1).astimezone(pytz.utc)
     NOT_FOUND = True
 
 if (

--- a/config.py
+++ b/config.py
@@ -9,7 +9,6 @@ IS_LOCAL = True if os.environ.get("IS_LOCAL", "False") == "True" else False
 
 if LocalFileHandler().check_file_exists(file_path="config.json"):
     local_datetime = LocalFileHandler().get_last_modified(file_path="config.json")
-    local_datetime = local_datetime.astimezone(pytz.utc)
     NOT_FOUND = False
 else:
     print("Local config not found")

--- a/config.py
+++ b/config.py
@@ -5,6 +5,19 @@ from utils.local_file_handler import LocalFileHandler
 
 IS_LOCAL = True if os.environ.get("IS_LOCAL", "False") == "True" else False
 
-CONFIGS = S3FileHandler().load_file(file_path="config.json")["CONFIGS"]
-if IS_LOCAL:
-    LocalFileHandler().save_file(file_path="config.json", data=CONFIGS)
+# Load configurations from S3
+s3_configs = S3FileHandler().load_file(file_path="config.json")["CONFIGS"]
+
+# Try to load configurations locally, if available
+try:
+    local_configs = LocalFileHandler().load_file(file_path="config.json")["CONFIGS"]
+except FileNotFoundError:
+    local_configs = None
+
+# Determine the final CONFIGS based on comparison between S3 and local configurations
+if s3_configs != local_configs:
+    CONFIGS = s3_configs
+    if IS_LOCAL:
+        LocalFileHandler().save_file(file_path="config.json", data=CONFIGS)
+else:
+    CONFIGS = local_configs

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ s3_configs = S3FileHandler().load_file(file_path="config.json")["CONFIGS"]
 
 # Try to load configurations locally, if available
 try:
-    local_configs = LocalFileHandler().load_file(file_path="config.json")["CONFIGS"]
+    local_configs = LocalFileHandler().load_file(file_path="config.json")
 except FileNotFoundError:
     local_configs = None
 

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 IS_LOCAL = True if os.environ.get("IS_LOCAL", "False") == "True" else False
 
+print(f"\nChecking for local config file and evaluating for updates from S3.")
+
 if LocalFileHandler().check_file_exists(file_path="config.json"):
     local_datetime = LocalFileHandler().get_last_modified(file_path="config.json")
     NOT_FOUND = False
@@ -19,8 +21,11 @@ if (
     NOT_FOUND
     or S3FileHandler().get_last_modified(file_path="config.json") > local_datetime
 ):
+    print("Loading config from S3")
     CONFIGS = S3FileHandler().load_file(file_path="config.json")
     if IS_LOCAL:
+        print("Saving config to local")
         LocalFileHandler().save_file(file_path="config.json", data=CONFIGS)
 else:
+    print("Loading config from local")
     CONFIGS = LocalFileHandler().load_file(file_path="config.json")

--- a/config.py
+++ b/config.py
@@ -1,23 +1,27 @@
 import boto3
 import os
+import pytz
 from utils.s3_file_handler import S3FileHandler
 from utils.local_file_handler import LocalFileHandler
+from datetime import datetime
 
 IS_LOCAL = True if os.environ.get("IS_LOCAL", "False") == "True" else False
 
-# Load configurations from S3
-s3_configs = S3FileHandler().load_file(file_path="config.json")["CONFIGS"]
+if LocalFileHandler().check_file_exists(file_path="config.json"):
+    local_datetime = LocalFileHandler().get_last_modified(file_path="config.json")
+    local_datetime = local_datetime.astimezone(pytz.utc)
+    NOT_FOUND = False
+else:
+    print("Local config not found")
+    local_datetime = datetime(1970, 1, 1).astimezone(pytz.utc)
+    NOT_FOUND = True
 
-# Try to load configurations locally, if available
-try:
-    local_configs = LocalFileHandler().load_file(file_path="config.json")
-except FileNotFoundError:
-    local_configs = None
-
-# Determine the final CONFIGS based on comparison between S3 and local configurations
-if s3_configs != local_configs:
-    CONFIGS = s3_configs
+if (
+    NOT_FOUND
+    or S3FileHandler().get_last_modified(file_path="config.json") > local_datetime
+):
+    CONFIGS = S3FileHandler().load_file(file_path="config.json")
     if IS_LOCAL:
         LocalFileHandler().save_file(file_path="config.json", data=CONFIGS)
 else:
-    CONFIGS = local_configs
+    CONFIGS = LocalFileHandler().load_file(file_path="config.json")

--- a/push_local_config_to_s3.py
+++ b/push_local_config_to_s3.py
@@ -1,5 +1,7 @@
 from utils.s3_file_handler import S3FileHandler
 from utils.local_file_handler import LocalFileHandler
+import json
 
-CONFIGS = LocalFileHandler().load_file(file_path="config.json")["CONFIGS"]
-S3FileHandler().save_json(file_path="config.json", data=CONFIGS)
+CONFIGS = LocalFileHandler().load_file(file_path="config.json")
+print(CONFIGS)
+S3FileHandler().save_json(file_path="config.json", data=json.dumps(CONFIGS))

--- a/push_local_config_to_s3.py
+++ b/push_local_config_to_s3.py
@@ -1,0 +1,5 @@
+from utils.s3_file_handler import S3FileHandler
+from utils.local_file_handler import LocalFileHandler
+
+CONFIGS = LocalFileHandler().load_file(file_path="config.json")["CONFIGS"]
+S3FileHandler().save_json(file_path="config.json", data=CONFIGS)

--- a/utils/file_handler.py
+++ b/utils/file_handler.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Any, Union
+from datetime import datetime
 
 
 class FileHandler(ABC):
@@ -48,9 +49,23 @@ class FileHandler(ABC):
         pass
 
     @abstractmethod
+    def check_file_exists(self, file_path: str) -> bool:
+        """
+        Check if a file exists.
+        """
+        pass
+
+    @abstractmethod
     def get_file_path(self, file_path: str) -> str:
         """
         Get the file path.
+        """
+        pass
+
+    @abstractmethod
+    def get_last_modified(self, file_path: str) -> datetime:
+        """
+        Get the last modified time of the file.
         """
         pass
 

--- a/utils/local_file_handler.py
+++ b/utils/local_file_handler.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from utils.file_handler import FileHandler
 from typing import Union, Any
 import json
@@ -14,6 +15,13 @@ class LocalFileHandler(FileHandler):
 
     def make_directory(self, directory: str):
         Path(directory).mkdir(parents=True, exist_ok=True)
+
+    def check_file_exists(self, file_path: str) -> bool:
+        return os.path.exists(file_path)
+
+    def get_last_modified(self, file_path: str) -> datetime:
+        last_modified_timestamp = os.path.getmtime(file_path)
+        return datetime.fromtimestamp(last_modified_timestamp)
 
     def get_file_path(self, file_path: str) -> str:
         return file_path

--- a/utils/local_file_handler.py
+++ b/utils/local_file_handler.py
@@ -5,6 +5,7 @@ import json
 import pandas as pd
 from pathlib import Path
 import os
+import pytz
 
 
 class LocalFileHandler(FileHandler):
@@ -21,7 +22,7 @@ class LocalFileHandler(FileHandler):
 
     def get_last_modified(self, file_path: str) -> datetime:
         last_modified_timestamp = os.path.getmtime(file_path)
-        return datetime.fromtimestamp(last_modified_timestamp)
+        return datetime.fromtimestamp(last_modified_timestamp).astimezone(pytz.utc)
 
     def get_file_path(self, file_path: str) -> str:
         return file_path

--- a/utils/s3_file_handler.py
+++ b/utils/s3_file_handler.py
@@ -6,6 +6,7 @@ import boto3
 import os
 import pickle
 import io
+from datetime import datetime
 
 
 S3_SCRAPER_BUCKET = os.environ.get("S3_SCRAPER_BUCKET")
@@ -25,6 +26,17 @@ class S3FileHandler(FileHandler):
     @property
     def file_missing_exception(self) -> Exception:
         return self.s3_client.exceptions.NoSuchKey
+
+    def check_file_exists(self, file_path: str) -> bool:
+        try:
+            self.s3_client.head_object(Bucket=S3_SCRAPER_BUCKET, Key=file_path)
+            return True
+        except self.file_missing_exception:
+            return False
+
+    def get_last_modified(self, file_path: str) -> datetime:
+        obj = self.s3_client.get_object(Bucket=S3_SCRAPER_BUCKET, Key=file_path)
+        return obj["LastModified"]
 
     def make_directory(self, directory: str):
         pass

--- a/utils/s3_file_handler.py
+++ b/utils/s3_file_handler.py
@@ -38,7 +38,7 @@ class S3FileHandler(FileHandler):
 
     def save_json(self, file_path: str, data: str):
         self.s3_client.put_object(
-            file_pathBucket=S3_SCRAPER_BUCKET, Key=file_path, body=data.encode("utf-8")
+            Bucket=S3_SCRAPER_BUCKET, Key=file_path, Body=data.encode("utf-8")
         )
 
     def load_jsonl(self, file_path: str) -> list[dict]:


### PR DESCRIPTION
Only download the S3 config if it is newer than the local config. Will not constantly overwrite the local file if the local file is newer.

Added a small script that uploads the config to S3, if you want to make updates.

Added new methods to the file handlers to check if a file exists, and to get the last modified timestamp. The local timestamp evaluator converts to UTC as a baseline.